### PR TITLE
- None in the paths related fields in OutputGenerationParams, and related test and exception 

### DIFF
--- a/src/servicepathmapper/common/types/exception_types/code_behavior_alert.py
+++ b/src/servicepathmapper/common/types/exception_types/code_behavior_alert.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 
 @dataclass
 class CodeBehaviorAlert(Exception):
-    alert: list[str]
+    alert: str
 
     def __str__(self) -> str:
         return f'Code behavior is suspicious:\n{self.alert}'

--- a/src/servicepathmapper/common/types/output_generation_params.py
+++ b/src/servicepathmapper/common/types/output_generation_params.py
@@ -13,8 +13,8 @@ class OutputGenerationParams:
                  entities: Entities,
                  out_dir_path: Path,
                  config_stats: dict,
-                 participation_counters: dict,
-                 paths_by_servers_group_by_len: PathsByServersGroupByLen,
+                 participation_counters: dict | None,
+                 paths_by_servers_group_by_len: PathsByServersGroupByLen | None,
                  stats_only: bool,
                  server_groups_only: bool,
                  max_threads: int):

--- a/src/servicepathmapper/io/input/get_args.py
+++ b/src/servicepathmapper/io/input/get_args.py
@@ -13,7 +13,6 @@ from servicepathmapper.common.types.exception_types.bad_type_error import BadTyp
 from servicepathmapper.common.types.exception_types.bad_value_error import BadValueError
 from servicepathmapper.common.types.exception_types.filesystem_error import FileSystemError
 from servicepathmapper.io.input.validate_args import validate_args
-
 from version import __version__
 
 
@@ -138,8 +137,8 @@ def _create_parser_groups(parser: argparse.ArgumentParser) -> tuple[
 
 
 def _add_args_to_parser_groups(
-    args_group_help: argparse._ArgumentGroup,
-    args_group_config: argparse._ArgumentGroup
+        args_group_help: argparse._ArgumentGroup,
+        args_group_config: argparse._ArgumentGroup
 ) -> None:
     for args_key, args_info in arg_info.ARG_INFO.items():
         metadata = args_info.get(arg_info.ARG_METADATA, 0)

--- a/src/servicepathmapper/io/output_generators/tests_capture.py
+++ b/src/servicepathmapper/io/output_generators/tests_capture.py
@@ -1,7 +1,6 @@
+import tests.tests_strings as tests_common
 from servicepathmapper.common.types.output_generation_params import OutputGenerationParams
 from servicepathmapper.io.output_generators.base import OutputGenerator
-
-import tests.tests_strings as tests_common
 
 
 class TestsCaptureOutputGenerator(OutputGenerator):

--- a/src/servicepathmapper/service_path_mapper.py
+++ b/src/servicepathmapper/service_path_mapper.py
@@ -4,6 +4,7 @@ import sys
 import servicepathmapper.common.strings.help as program_help
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.io.input.arg_info as arg_info
+import tests.tests_strings as tests_common
 from servicepathmapper.common.logger import Logger
 from servicepathmapper.common.strings.about import PACKAGE_NAME
 from servicepathmapper.common.types.config_stats import ConfigStats
@@ -14,8 +15,6 @@ from servicepathmapper.io.input.process_args import process_program_args
 from servicepathmapper.io.output_generators.base import OutputGenerator
 from servicepathmapper.io.output_generators.file_system import FileSystemOutputGenerator
 from servicepathmapper.logic.paths import map_paths
-
-import tests.tests_strings as tests_common
 
 
 def main(test_config: dict = None, output_generator: OutputGenerator = None) -> int | dict:

--- a/tests/test_cases/args/boolean_values_flexibility/test_case.py
+++ b/tests/test_cases/args/boolean_values_flexibility/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.io.output_generators.tests_dummy import DummyOutputGenerator
 from servicepathmapper.service_path_mapper import main

--- a/tests/test_cases/args/cli_overrides_config_max_path_len/test_case.py
+++ b/tests/test_cases/args/cli_overrides_config_max_path_len/test_case.py
@@ -2,9 +2,9 @@ import json
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.io.input.get_args import get_program_args
-
 from tests.tests_common import config_to_jsonable
 
 

--- a/tests/test_cases/args/cli_overrides_config_stats_only_flag_0_to_1/test_case.py
+++ b/tests/test_cases/args/cli_overrides_config_stats_only_flag_0_to_1/test_case.py
@@ -2,9 +2,9 @@ import json
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.io.input.get_args import get_program_args
-
 from tests.tests_common import config_to_jsonable
 
 

--- a/tests/test_cases/args/cli_overrides_config_stats_only_flag_1_to_0/test_case.py
+++ b/tests/test_cases/args/cli_overrides_config_stats_only_flag_1_to_0/test_case.py
@@ -2,9 +2,9 @@ import json
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.io.input.get_args import get_program_args
-
 from tests.tests_common import config_to_jsonable
 
 

--- a/tests/test_cases/args/cli_overrides_no_stats_only_with_config_stats_only/test_case.py
+++ b/tests/test_cases/args/cli_overrides_no_stats_only_with_config_stats_only/test_case.py
@@ -2,9 +2,9 @@ import json
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.io.input.get_args import get_program_args
-
 from tests.tests_common import config_to_jsonable
 
 

--- a/tests/test_cases/exceptions/bad_type/boolean_arg_bad_type/test_case.py
+++ b/tests/test_cases/exceptions/bad_type/boolean_arg_bad_type/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.bad_type_error import BadTypeError
 from servicepathmapper.io.output_generators.tests_dummy import DummyOutputGenerator

--- a/tests/test_cases/exceptions/bad_type/int_arg_bad_type/test_case.py
+++ b/tests/test_cases/exceptions/bad_type/int_arg_bad_type/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.bad_type_error import BadTypeError
 from servicepathmapper.io.output_generators.tests_dummy import DummyOutputGenerator

--- a/tests/test_cases/exceptions/bad_type/int_arg_bad_type_empty_str/test_case.py
+++ b/tests/test_cases/exceptions/bad_type/int_arg_bad_type_empty_str/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.bad_type_error import BadTypeError
 from servicepathmapper.io.output_generators.tests_dummy import DummyOutputGenerator

--- a/tests/test_cases/exceptions/bad_value/invalid_config_json/test_case.py
+++ b/tests/test_cases/exceptions/bad_value/invalid_config_json/test_case.py
@@ -2,6 +2,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.bad_value_error import BadValueError
 from servicepathmapper.io.input.get_args import _load_config_file

--- a/tests/test_cases/exceptions/bad_value/path_length/max_path_len_less_than_2/test_case.py
+++ b/tests/test_cases/exceptions/bad_value/path_length/max_path_len_less_than_2/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.bad_value_error import BadValueError
 from servicepathmapper.io.output_generators.tests_dummy import DummyOutputGenerator

--- a/tests/test_cases/exceptions/bad_value/path_length/max_path_len_too_big/test_case.py
+++ b/tests/test_cases/exceptions/bad_value/path_length/max_path_len_too_big/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.constants import PATH_LEN_MAX_LIMIT
 from servicepathmapper.common.types.exception_types.bad_value_error import BadValueError

--- a/tests/test_cases/exceptions/bad_value/path_length/min_path_len_bigger_than_max/test_case.py
+++ b/tests/test_cases/exceptions/bad_value/path_length/min_path_len_bigger_than_max/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.bad_value_error import BadValueError
 from servicepathmapper.io.output_generators.tests_dummy import DummyOutputGenerator

--- a/tests/test_cases/exceptions/bad_value/path_length/min_path_len_less_than_2/test_case.py
+++ b/tests/test_cases/exceptions/bad_value/path_length/min_path_len_less_than_2/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.bad_value_error import BadValueError
 from servicepathmapper.io.output_generators.tests_dummy import DummyOutputGenerator

--- a/tests/test_cases/exceptions/code_behavior_alert/no_paths_no_stats_only/test_case.py
+++ b/tests/test_cases/exceptions/code_behavior_alert/no_paths_no_stats_only/test_case.py
@@ -1,4 +1,5 @@
 import pytest
+
 from servicepathmapper.common.types.entities import Entities
 from servicepathmapper.common.types.exception_types.code_behavior_alert import CodeBehaviorAlert
 from servicepathmapper.common.types.output_generation_params import OutputGenerationParams
@@ -22,5 +23,8 @@ def test_generate_output_raises_on_none_paths(tmp_path):
         stats_only=False,
         max_threads=1
     )
-    with pytest.raises(CodeBehaviorAlert):
+    with pytest.raises(CodeBehaviorAlert) as exc_info:
         output_gen._generate_output(params)
+
+    alert = exc_info.value.alert
+    assert 'Paths is unexpectedly None!' in alert

--- a/tests/test_cases/exceptions/conflicting_args/allowed_and_forbidden_servers/test_case.py
+++ b/tests/test_cases/exceptions/conflicting_args/allowed_and_forbidden_servers/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.conflicting_args_error import ConflictingArgsError
 from servicepathmapper.io.output_generators.tests_dummy import DummyOutputGenerator

--- a/tests/test_cases/exceptions/conflicting_args/allowed_and_forbidden_services/test_case.py
+++ b/tests/test_cases/exceptions/conflicting_args/allowed_and_forbidden_services/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.conflicting_args_error import ConflictingArgsError
 from servicepathmapper.io.output_generators.tests_dummy import DummyOutputGenerator

--- a/tests/test_cases/exceptions/file_system_errors/clients_dir_empty_str/test_case.py
+++ b/tests/test_cases/exceptions/file_system_errors/clients_dir_empty_str/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.filesystem_error import FileSystemError
 from servicepathmapper.io.output_generators.tests_dummy import DummyOutputGenerator

--- a/tests/test_cases/exceptions/file_system_errors/clients_dir_not_found/test_case.py
+++ b/tests/test_cases/exceptions/file_system_errors/clients_dir_not_found/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.filesystem_error import FileSystemError
 from servicepathmapper.io.output_generators.tests_dummy import DummyOutputGenerator

--- a/tests/test_cases/exceptions/file_system_errors/dst_server_not_in_providers_dir/test_case.py
+++ b/tests/test_cases/exceptions/file_system_errors/dst_server_not_in_providers_dir/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.filesystem_error import FileSystemError
 from servicepathmapper.io.output_generators.tests_dummy import DummyOutputGenerator

--- a/tests/test_cases/exceptions/file_system_errors/load_config_file/test_case.py
+++ b/tests/test_cases/exceptions/file_system_errors/load_config_file/test_case.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.filesystem_error import FileSystemError
 from servicepathmapper.io.input.get_args import _load_config_file

--- a/tests/test_cases/exceptions/file_system_errors/providers_dir_not_found/test_case.py
+++ b/tests/test_cases/exceptions/file_system_errors/providers_dir_not_found/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.filesystem_error import FileSystemError
 from servicepathmapper.io.output_generators.tests_dummy import DummyOutputGenerator

--- a/tests/test_cases/exceptions/file_system_errors/read_lines_from_non_existing_file/test_case.py
+++ b/tests/test_cases/exceptions/file_system_errors/read_lines_from_non_existing_file/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 from servicepathmapper.common.types.exception_types.filesystem_error import FileSystemError
 from servicepathmapper.io.input.process_args import _read_lines_from_file
 

--- a/tests/test_cases/exceptions/file_system_errors/src_server_not_in_clients_dir/test_case.py
+++ b/tests/test_cases/exceptions/file_system_errors/src_server_not_in_clients_dir/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.filesystem_error import FileSystemError
 from servicepathmapper.io.output_generators.tests_dummy import DummyOutputGenerator

--- a/tests/test_cases/exceptions/logic_errors/mandatory_server_is_forbidden/test_case.py
+++ b/tests/test_cases/exceptions/logic_errors/mandatory_server_is_forbidden/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.logic_error import LogicError
 from servicepathmapper.io.output_generators.tests_dummy import DummyOutputGenerator

--- a/tests/test_cases/exceptions/logic_errors/mandatory_service_is_forbidden/test_case.py
+++ b/tests/test_cases/exceptions/logic_errors/mandatory_service_is_forbidden/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.logic_error import LogicError
 from servicepathmapper.io.output_generators.tests_dummy import DummyOutputGenerator

--- a/tests/test_cases/exceptions/logic_errors/mandatory_service_provided_by_none/test_case.py
+++ b/tests/test_cases/exceptions/logic_errors/mandatory_service_provided_by_none/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.logic_error import LogicError
 from servicepathmapper.io.output_generators.tests_dummy import DummyOutputGenerator

--- a/tests/test_cases/exceptions/logic_errors/src_server_is_dst_server/test_case.py
+++ b/tests/test_cases/exceptions/logic_errors/src_server_is_dst_server/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.logic_error import LogicError
 from servicepathmapper.io.output_generators.tests_dummy import DummyOutputGenerator

--- a/tests/test_cases/exceptions/missing_args/clients_dir/test_case.py
+++ b/tests/test_cases/exceptions/missing_args/clients_dir/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.missing_args_error import MissingArgsError
 from servicepathmapper.io.output_generators.tests_dummy import DummyOutputGenerator

--- a/tests/test_cases/exceptions/missing_args/dst_server/test_case.py
+++ b/tests/test_cases/exceptions/missing_args/dst_server/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.missing_args_error import MissingArgsError
 from servicepathmapper.io.output_generators.tests_dummy import DummyOutputGenerator

--- a/tests/test_cases/exceptions/missing_args/max_path_len/test_case.py
+++ b/tests/test_cases/exceptions/missing_args/max_path_len/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.missing_args_error import MissingArgsError
 from servicepathmapper.io.output_generators.tests_dummy import DummyOutputGenerator

--- a/tests/test_cases/exceptions/missing_args/providers_dir/test_case.py
+++ b/tests/test_cases/exceptions/missing_args/providers_dir/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.missing_args_error import MissingArgsError
 from servicepathmapper.io.output_generators.tests_dummy import DummyOutputGenerator

--- a/tests/test_cases/exceptions/missing_args/src_server/test_case.py
+++ b/tests/test_cases/exceptions/missing_args/src_server/test_case.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.types.exception_types.missing_args_error import MissingArgsError
 from servicepathmapper.io.output_generators.tests_dummy import DummyOutputGenerator

--- a/tests/test_cases/exceptions/threading/file_error_reporting/test_case.py
+++ b/tests/test_cases/exceptions/threading/file_error_reporting/test_case.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+
 from servicepathmapper.common.types.entities import Entities
 from servicepathmapper.common.types.exception_types.filesystem_error import FileSystemError
 from servicepathmapper.io.output_generators.file_system import FileSystemOutputGenerator

--- a/tests/test_cases/runtime_messages/insufficient_resources_for_goal/test_case.py
+++ b/tests/test_cases/runtime_messages/insufficient_resources_for_goal/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 from servicepathmapper.common.constants import PATH_LEN_MAX_LIMIT
-
 from ..run_test_case import run_test_case
 
 

--- a/tests/test_cases/tests_capture/paths/allowed_and_mandatory_same_servers/test_case.py
+++ b/tests/test_cases/tests_capture/paths/allowed_and_mandatory_same_servers/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 

--- a/tests/test_cases/tests_capture/paths/allowed_servers/test_case.py
+++ b/tests/test_cases/tests_capture/paths/allowed_servers/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 

--- a/tests/test_cases/tests_capture/paths/allowed_services/test_case.py
+++ b/tests/test_cases/tests_capture/paths/allowed_services/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 

--- a/tests/test_cases/tests_capture/paths/forbidden_servers/test_case.py
+++ b/tests/test_cases/tests_capture/paths/forbidden_servers/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 

--- a/tests/test_cases/tests_capture/paths/forbidden_services/test_case.py
+++ b/tests/test_cases/tests_capture/paths/forbidden_services/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 

--- a/tests/test_cases/tests_capture/paths/mandatory_servers/test_case.py
+++ b/tests/test_cases/tests_capture/paths/mandatory_servers/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 

--- a/tests/test_cases/tests_capture/paths/mandatory_servers_implicitly_allowed/test_case.py
+++ b/tests/test_cases/tests_capture/paths/mandatory_servers_implicitly_allowed/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 

--- a/tests/test_cases/tests_capture/paths/mandatory_services/test_case.py
+++ b/tests/test_cases/tests_capture/paths/mandatory_services/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 

--- a/tests/test_cases/tests_capture/paths/mandatory_services_implicitly_allowed/test_case.py
+++ b/tests/test_cases/tests_capture/paths/mandatory_services_implicitly_allowed/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 

--- a/tests/test_cases/tests_capture/paths/server_not_participating_as_all_clients_are_forbidden/test_case.py
+++ b/tests/test_cases/tests_capture/paths/server_not_participating_as_all_clients_are_forbidden/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 

--- a/tests/test_cases/tests_capture/paths/server_not_participating_as_all_providers_are_not_in_allowed/test_case.py
+++ b/tests/test_cases/tests_capture/paths/server_not_participating_as_all_providers_are_not_in_allowed/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 

--- a/tests/test_cases/tests_capture/paths/server_not_participating_due_to_max_path_len/test_case.py
+++ b/tests/test_cases/tests_capture/paths/server_not_participating_due_to_max_path_len/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 

--- a/tests/test_cases/tests_capture/paths/server_not_participating_due_to_min_path_len/test_case.py
+++ b/tests/test_cases/tests_capture/paths/server_not_participating_due_to_min_path_len/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 

--- a/tests/test_cases/tests_capture/paths/simple_test/test_case.py
+++ b/tests/test_cases/tests_capture/paths/simple_test/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 

--- a/tests/test_cases/tests_capture/paths/zero_resolting_paths/test_case.py
+++ b/tests/test_cases/tests_capture/paths/zero_resolting_paths/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 

--- a/tests/test_cases/tests_capture/run_test_case.py
+++ b/tests/test_cases/tests_capture/run_test_case.py
@@ -1,11 +1,11 @@
 from typing import TypeAlias
 
 from deepdiff import DeepDiff
+
 from servicepathmapper.common.types.entities import Entities
 from servicepathmapper.common.types.paths_type_hints import PathsByServersGroupByLen
 from servicepathmapper.io.output_generators.tests_capture import TestsCaptureOutputGenerator
 from servicepathmapper.service_path_mapper import main
-
 from ... import tests_strings as tests_common
 
 

--- a/tests/test_cases/tests_capture/stats_only/config_stats__only_with_forbidden_servers/test_case.py
+++ b/tests/test_cases/tests_capture/stats_only/config_stats__only_with_forbidden_servers/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 

--- a/tests/test_cases/tests_capture/stats_only/config_stats_only/test_case.py
+++ b/tests/test_cases/tests_capture/stats_only/config_stats_only/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 

--- a/tests/test_cases/tests_capture/stats_only/config_stats_only_with_services_having_providers_no_clients/test_case.py
+++ b/tests/test_cases/tests_capture/stats_only/config_stats_only_with_services_having_providers_no_clients/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 

--- a/tests/test_cases/tests_capture/stats_only/config_stats_sorting/test_case.py
+++ b/tests/test_cases/tests_capture/stats_only/config_stats_sorting/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 

--- a/tests/test_cases/tests_capture/stats_only/stats_only/test_case.py
+++ b/tests/test_cases/tests_capture/stats_only/stats_only/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 

--- a/tests/test_cases/tests_capture/stats_only/stats_only_and_config_stats_only_both_false/test_case.py
+++ b/tests/test_cases/tests_capture/stats_only/stats_only_and_config_stats_only_both_false/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 

--- a/tests/test_cases/tests_capture/stats_only/stats_only_and_config_stats_only_both_true/test_case.py
+++ b/tests/test_cases/tests_capture/stats_only/stats_only_and_config_stats_only_both_true/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 

--- a/tests/test_cases/tests_capture/stats_only/stats_only_implied_by_config_stats_only/test_case.py
+++ b/tests/test_cases/tests_capture/stats_only/stats_only_implied_by_config_stats_only/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 

--- a/tests/test_cases/tests_capture/stats_only/stats_only_with_forbidden_servers/test_case.py
+++ b/tests/test_cases/tests_capture/stats_only/stats_only_with_forbidden_servers/test_case.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import servicepathmapper.common.strings.program_args as program_args
 import servicepathmapper.common.strings.stats as output_stats
-
 import tests.tests_strings as tests_common
 from ...run_test_case import run_test_case
 


### PR DESCRIPTION
- Added None to the type hints of paths and participations counters in OutputGenerationParams
- Fixed the type of the field 'alert' in exception class CodeBehaviorAlert, and added assert in its test case
- Spacing and imports reordering automatically done by pychaem